### PR TITLE
DeskbarView: call BView::MessageReceived if we don't handle the message

### DIFF
--- a/deskbar add-on/DeskbarView.cpp
+++ b/deskbar add-on/DeskbarView.cpp
@@ -167,7 +167,8 @@ void DeskbarView::MessageReceived( BMessage *msg ) {
 	if (msg->what=='Remv') {
 		BDeskbar deskbar;
 		deskbar.RemoveItem(VIEW_NAME);
-	}
+	} else
+		BView::MessageReceived(msg);
 
 }
 


### PR DESCRIPTION
This fixes mouse button handling in the Deskbar replicant.